### PR TITLE
Shorten to circle platforms ➊ for MTR & LRT

### DIFF
--- a/src/lightRail.ts
+++ b/src/lightRail.ts
@@ -1,5 +1,5 @@
 import type { Eta, RouteListEntry } from "./type";
-import { isSafari } from "./utils";
+import { isSafari, getPlatformDisplay } from "./utils";
 
 interface fetchEtasProps {
   route: RouteListEntry["route"];
@@ -58,10 +58,10 @@ export default function fetchEtas({
                     -2,
                   )}:${`0${etaDate.getSeconds()}`.slice(-2)}+08:00`,
                 remark: {
-                  zh: `${platform_id}號月台 - ${Array(train_length)
+                  zh: `${getPlatformDisplay(platform_id, "zh")} - ${Array(train_length)
                     .fill("▭")
                     .join("")}`,
-                  en: `Platform ${platform_id} - ${Array(train_length)
+                  en: `${getPlatformDisplay(platform_id, "en")} - ${Array(train_length)
                     .fill("▭")
                     .join("")}`,
                 },

--- a/src/mtr.ts
+++ b/src/mtr.ts
@@ -1,5 +1,5 @@
 import type { Eta, RouteListEntry, StopList } from "./type";
-import { isSafari } from "./utils";
+import { isSafari, getPlatformDisplay } from "./utils";
 
 interface fetchEtasProps {
   route: RouteListEntry["route"];
@@ -32,8 +32,8 @@ export default function fetchEtas({
               {
                 eta: time.replace(" ", "T") + "+08:00",
                 remark: {
-                  zh: `${plat}號月台`,
-                  en: `Platform ${plat}`,
+                  zh: `${getPlatformDisplay(plat, "zh")}`,
+                  en: `${getPlatformDisplay(plat, "en")}`,
                 },
                 dest: {
                   zh: stopList[dest].name.zh,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,20 @@ export const isSafari = (() => {
     return false;
   }
 })();
+
+export function getPlatformDisplay(
+  plat: number | string, 
+  lang: string
+): string {
+  const number = typeof plat === 'string' ? parseInt(plat) : plat;
+  if (number < 0 || number > 20) {
+    return lang == "en" ? `Platform ${number}` : `${number}號月台`;
+  }
+  if (number === 0) {
+    return "⓿";
+  }
+  if (number > 10) {
+    return String.fromCharCode(9451 + (number - 11));
+  }
+  return String.fromCharCode(10102 + (number - 1));
+}


### PR DESCRIPTION
Shorten platform numbers to circles for MTR & LRT as suggested in telegram. ➊

Fallback to text if there isn't a Unicode character available for that number, tho in practice it should never happen, there are no platforms -1, 21 or 9.75 in Hong Kong.

There's also a PR for the [Python counterpart](https://github.com/hkbus/hk-bus-crawling/pull/9).