### PR TITLE
More precise journey time

### DIFF
--- a/src/journeyTime.ts
+++ b/src/journeyTime.ts
@@ -49,7 +49,18 @@ export async function fetchEstJourneyTime({
         signal,
       })
         .then(r => r.json())
-        .then(({eta}) => {
+        .then(({eta, distM, jSpeed}) => {
+          const speedStr = /(\d+)公里\/小時/g.exec(jSpeed)?.[1];
+          if (
+            speedStr !== null &&
+            speedStr !== undefined &&
+            !isNaN(parseInt(speedStr, 10))
+          ) {
+            return (distM / parseInt(speedStr, 10) / 1000) * 60;
+          }
+          console.warn(
+            "Unable to parse TDAS response for more precise journey time. Falling back."
+          );
           const [hh, mm] = eta.split(":").map((v: string) => parseInt(v, 10))
           return hh * 60 + mm;
         })

--- a/src/journeyTime.ts
+++ b/src/journeyTime.ts
@@ -51,11 +51,15 @@ export async function fetchEstJourneyTime({
         .then(r => r.json())
         .then(({eta}) => {
           const [hh, mm] = eta.split(":").map((v: string) => parseInt(v, 10))
-          return hh * 60 + mm + 1;
+          return hh * 60 + mm;
         })
         .catch(() => {
-          //  for any error, assume 5 minutes travel time blindly
-          return 5;
+          //  for any error, assume 4 minutes journey time blindly
+          return 4;
+        })
+        .then(m => {
+          // margin for car accelerating, decelerating, and passenger picking up and dropping off
+          return m + 1
         })
     ))
     minutes.forEach(m => {


### PR DESCRIPTION
TDAS seems to always round **up** (not round **off**) journey time to the nearest minute. The error would be huge when many journey times are added up. Calculating the journey time from `distM` (in meter accurate to the nearest integer) and `jSpeed` (in km/h accurate to the nearest km/h) can get an eta with higher accuracy. I haven't found any cases that prove such a calculation would be inaccurate (e.g. `eta` has taken account of any additional factors other than `distM` and `jSpeed`).

[TDAS API Specifications](https://tdas-api.hkemobility.gov.hk/tdas/specification/TD_TDAS_API_Specifications.pdf) have the following field explanations:
- `jSpeed`: Overall average journey speed in km/h
- `distM`: Total distance in meter
- `eta`: Estimated journey time in hh:mm

In the example below, `distM / jSpeed / 1000 * 60` = 498 / 25 / 1000 * 60 = 1.1952 mins = 1 min 11.7 sec. Meanwhile, `eta` reports 2 mins.
```json
{
    "jSpeed": "25公里/小時",
    "distM": 498,
    "distU": "500米",
    "eta": "00:02",
    "cht": false,
    "eht": false,
    "wht": false,
    "route": [
        "..."
    ]
}
```