### PR TITLE
fix disabled GMB ETA

### DIFF
--- a/src/gmb.ts
+++ b/src/gmb.ts
@@ -30,20 +30,40 @@ export default function fetchEtas({
         )
         .filter(({ stop_seq }: any) => stop_seq === seq + 1)
         .reduce(
-          (acc: Eta[], { eta }: any) => [
+          (
+            acc: Eta[],
+            { enabled, eta, description_tc, description_en }: any
+          ) => [
             ...acc,
-            ...eta.map((data: any) => ({
-              eta: data.timestamp,
-              remark: {
-                zh: data.remarks_tc ?? "",
-                en: data.remarks_en ?? "",
-              },
-              dest: {
-                zh: "",
-                en: "",
-              },
-              co: "gmb",
-            })),
+            ...(enabled
+              ? eta.map((data: any) => {
+                  return {
+                    eta: data.timestamp,
+                    remark: {
+                      zh: data.remarks_tc ?? "",
+                      en: data.remarks_en ?? "",
+                    },
+                    dest: {
+                      zh: "",
+                      en: "",
+                    },
+                    co: "gmb",
+                  };
+                })
+              : [
+                  {
+                    eta: null,
+                    remark: {
+                      zh: description_tc ?? "",
+                      en: description_en ?? "",
+                    },
+                    dest: {
+                      zh: "",
+                      en: "",
+                    },
+                    co: "gmb",
+                  },
+                ]),
           ],
           [],
         ),


### PR DESCRIPTION
GMB ETA may be disabled. Sample response:

```json
{
    "type": "ETA-Route-Stop",
    "version": "1.0",
    "generated_timestamp": "2024-09-06T00:00:00.000+08:00",
    "data": [
        {
            "route_seq": 1,
            "stop_seq": 1,
            "enabled": false,
            "description_tc": "八號烈風或暴風信號現正生效。到站預報將臨時停用到另行通知。",
            "description_sc": "八号烈风或暴风信号现正生效。到站预报将临时停用到另行通知。",
            "description_en": "No. 8 Gale or Storm Signal is in force. The estimated time of arrival service will be disabled until further notice."
        }
    ]
}
```

In that situation, currently `fetchEtas` returns
```
TypeError: Cannot read properties of undefined (reading 'map')
    at index-DLz6FC2X.js:83:42044
    at Array.reduce (<anonymous>)
    at index-DLz6FC2X.js:83:42013
    at async X2 (index-DLz6FC2X.js:83:45335)
```

This PR wraps it to
```json
[
    {
        "eta": null,
        "remark": {
            "zh": "八號烈風或暴風信號現正生效。到站預報將臨時停用到另行通知。",
            "en": "No. 8 Gale or Storm Signal is in force. The estimated time of arrival service will be disabled until further notice."
        },
        "dest": {
            "zh": "",
            "en": ""
        },
        "co": "gmb"
    }
]
```
which aligns to e.g. KMB
```json
[
    {
        "eta": null,
        "remark": {
            "zh": "暫停預報",
            "en": "ETA service suspended"
        },
        "dest": {
            "zh": "竹園邨",
            "en": "CHUK YUEN ESTATE"
        },
        "co": "kmb"
    }
]
```