### PR TITLE
Add handling LRT ETA API status

### DIFF
--- a/src/lightRail.ts
+++ b/src/lightRail.ts
@@ -21,8 +21,9 @@ export default function fetchEtas({
     },
   )
     .then((response) => response.json())
-    .then(({ platform_list }) =>
-      platform_list.reduce(
+    .then(({ status, platform_list }) => {
+      if (status === 0) return [];
+      return platform_list.reduce(
         (acc: Eta[], { route_list, platform_id }: any) => [
           ...acc,
           ...route_list
@@ -74,8 +75,8 @@ export default function fetchEtas({
             }, []),
         ],
         [],
-      ),
-    )
+      )
+    })
     .catch((e) => {
       console.error(e);
       return [];


### PR DESCRIPTION
LRT ETA API has a field `status`. This field is currently unused on our end. This PR adds handling the isdelay field and aligns with our handling of `status` in MTR ETA API.

> https://opendata.mtr.com.hk/doc/LR_Next_Train_DataDictionary_v1.0.pdf
> status
> Number
> system status code
> value:
> "1" = normal
> “0” = error or alert


Our existing handling of `status` in MTR ETA API:
https://github.com/hkbus/hk-bus-eta/blob/e2b2020b81e7e6a1ac9159ed7882c80ba5a4d602/src/mtr.ts#L24-L26
