### PR TITLE
Add show MTR ETA message

### DIFF
--- a/src/mtr.ts
+++ b/src/mtr.ts
@@ -29,28 +29,48 @@ export default function fetchEtas({
       )
     ))
     .then((response) => response.json())
-    .then(({ data, status }) =>
-      status === 0
-        ? []
-        : data[`${route}-${stopId}`][
-            bound.endsWith("UT") ? "UP" : "DOWN"
-          ].reduce(
-            (acc: Eta[], { time, plat, dest }: any) => [
-              ...acc,
-              {
-                eta: time.replace(" ", "T") + "+08:00",
-                remark: {
-                  zh: `${plat}號月台`,
-                  en: `Platform ${plat}`,
-                },
-                dest: {
-                  zh: stopList[dest].name.zh,
-                  en: stopList[dest].name.en,
-                },
-                co: "mtr",
+    .then(({ data, message, status, url }) => {
+      if (status === 0) {
+        if (message && typeof message === "string") {
+          const message2 = message
+            .replace("Please click here for more information.", "")
+            .trim();
+          return [
+            {
+              eta: null,
+              remark: {
+                zh: message2,
+                en: message2,
               },
-            ],
-            [],
-          ),
-    );
+              dest: {
+                zh: "",
+                en: "",
+              },
+              co: "mtr",
+            },
+          ];
+        }
+        return [];
+      }
+      return data[`${route}-${stopId}`][
+        bound.endsWith("UT") ? "UP" : "DOWN"
+      ].reduce(
+        (acc: Eta[], { time, plat, dest }: any) => [
+          ...acc,
+          {
+            eta: time.replace(" ", "T") + "+08:00",
+            remark: {
+              zh: `${plat}號月台`,
+              en: `Platform ${plat}`,
+            },
+            dest: {
+              zh: stopList[dest].name.zh,
+              en: stopList[dest].name.en,
+            },
+            co: "mtr",
+          },
+        ],
+        []
+      );
+    });
 }


### PR DESCRIPTION
Sample MTR ETA API response payload (single language only)
```json
{
  "resultCode": 1,
  "timestamp": "2025-05-22 20:00:00",
  "url": "https://tnews.mtr.com.hk/alert/alert_title_wap.html",
  "curr_time": "-",
  "isTrafficNews": "Y",
  "status": 0,
  "message": "Special train service arrangements are now in place on this line. Please click here for more information."
}
```

Response after this PR:
```json
[
    {
        "eta": null,
        "remark": {
            "zh": "Special train service arrangements are now in place on this line.",
            "en": "Special train service arrangements are now in place on this line."
        },
        "dest": {
            "zh": "",
            "en": ""
        },
        "co": "mtr"
    }
]
```