### PR TITLE
Update lightRail.ts to handle additionalInfo1, routeRemarkEng2, route…

### DIFF
--- a/src/lightRail.ts
+++ b/src/lightRail.ts
@@ -13,7 +13,9 @@ export default function fetchEtas({
   dest,
 }: fetchEtasProps): Promise<Eta[]> {
   return fetch(
-    `https://rt.data.gov.hk/v1/transport/mtr/lrt/getSchedule?station_id=${stopId.slice(2,)}&with_special=1`,
+    `https://rt.data.gov.hk/v1/transport/mtr/lrt/getSchedule?station_id=${stopId.slice(
+      2,
+    )}&with_special=1`,
     {
       cache: isSafari ? "default" : "no-store",
     },
@@ -38,62 +40,92 @@ export default function fetchEtas({
           },
         ];
       }
-      // How should `end_service_status` for only some platforms be handled? Would a light rail line stop at different platforms?
+
       return platform_list.reduce(
         (acc: Eta[], { route_list, platform_id }: any) => {
           return [
             ...acc,
-            // route_list is null when there are no ETAs available
             ...(route_list ?? [])
               .filter(
-                ({ route_no, dest_ch, dest_en, stop }: any) =>
-                  route === route_no &&
+                ({
+                  route_no,
+                  additionalInfo1,
+                  dest_ch,
+                  dest_en,
+                  stop,
+                }: any) =>
+                  // match route number OR additionalInfo1 to the requested route
+                  (route === route_no || route === additionalInfo1) &&
                   (dest_ch === dest.zh || dest_en.includes("Circular")) &&
                   stop === 0,
               )
-              .map(({ time_en, train_length }: any) => {
-                let waitTime = 0;
-                switch (time_en.toLowerCase()) {
-                  case "arriving":
-                  case "departing":
-                  case "-":
-                    waitTime = 0;
-                    break;
-                  default:
-                    waitTime = parseInt(time_en, 10);
-                    break;
-                }
-                const etaDate = new Date(
-                  Date.now() + waitTime * 60 * 1000 + 8 * 3600000,
-                );
-                return {
-                  eta:
-                    `${etaDate.getUTCFullYear()}-${`0${
-                      etaDate.getUTCMonth() + 1
-                    }`.slice(-2)}-${`0${etaDate.getUTCDate()}`.slice(-2)}` +
-                    `T${`0${etaDate.getUTCHours()}`.slice(
-                      -2,
-                    )}:${`0${etaDate.getMinutes()}`.slice(
-                      -2,
-                    )}:${`0${etaDate.getSeconds()}`.slice(-2)}+08:00`,
-                  remark: {
-                    zh: `${platform_id}號月台 - ${Array(train_length)
-                      .fill("▭")
-                      .join("")}`,
-                    en: `Platform ${platform_id} - ${Array(train_length)
-                      .fill("▭")
-                      .join("")}`,
-                  },
-                  dest: {
-                    zh: "",
-                    en: "",
-                  },
-                  co: "lightRail",
-                };
-              }, []),
+              .map(
+                ({
+                  time_en,
+                  train_length,
+                  routeRemarkEng2,
+                  routeRemarkChi2,
+                }: any) => {
+                  let waitTime = 0;
+                  switch (time_en.toLowerCase()) {
+                    case "arriving":
+                    case "departing":
+                    case "-":
+                      waitTime = 0;
+                      break;
+                    default:
+                      waitTime = parseInt(time_en, 10);
+                      break;
+                  }
+                  const etaDate = new Date(
+                    Date.now() + waitTime * 60 * 1000 + 8 * 3600000,
+                  );
+
+                  const platformText = `${platform_id}號月台 - ${Array(
+                    train_length,
+                  )
+                    .fill("▭")
+                    .join("")}`;
+
+                  const platformTextEn = `Platform ${platform_id} - ${Array(
+                    train_length,
+                  )
+                    .fill("▭")
+                    .join("")}`;
+
+                  // Append routeRemarkEng2 / routeRemarkChi2 if present
+                  const remarkZh = routeRemarkChi2
+                    ? `${platformText} - ${routeRemarkChi2}`
+                    : platformText;
+                  const remarkEn = routeRemarkEng2
+                    ? `${platformTextEn} - ${routeRemarkEng2}`
+                    : platformTextEn;
+
+                  return {
+                    eta:
+                      `${etaDate.getUTCFullYear()}-${`0${
+                        etaDate.getUTCMonth() + 1
+                      }`.slice(-2)}-${`0${etaDate.getUTCDate()}`.slice(-2)}` +
+                      `T${`0${etaDate.getUTCHours()}`.slice(
+                        -2,
+                      )}:${`0${etaDate.getMinutes()}`.slice(
+                        -2,
+                      )}:${`0${etaDate.getSeconds()}`.slice(-2)}+08:00`,
+                    remark: {
+                      zh: remarkZh,
+                      en: remarkEn,
+                    },
+                    dest: {
+                      zh: "",
+                      en: "",
+                    },
+                    co: "lightRail",
+                  };
+                },
+              ),
           ];
         },
-        []
+        [],
       );
     })
     .catch((e) => {


### PR DESCRIPTION
…RemarkChi2

This is a part of [Update lightRail.py with separated csv urls](https://github.com/hkbus/hk-bus-crawling/pull/44) phase 1.5.

I have mentioned that we need to recognize special routes' number via the value of additionalInfo1.

by GPT-5 mini:

Here’s an updated version of your function that:
- identifies additionalInfo1 the same way as route_no,
- appends routeRemarkEng2 to remark.en,
- appends routeRemarkChi2 to remark.zh.

Changes:
- When filtering route_list we compare additionalInfo1 the same way as route_no.
- When building each ETA remark we include routeRemarkEng2 / routeRemarkChi2 (if present) after the platform/train-length text.
- Kept types as any where original code used them; you can narrow them later.