### PR TITLE
Compare the ferry service-day mask to "1" instead of truthiness

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,7 +78,7 @@ export const getUpcomingFerry = ({
           if (serviceDayMap[serviceKey][0] === "1") {
             return acc.concat(getEta(freq[serviceKey], refDate));
           }
-        } else if (serviceDayMap[serviceKey][refDate.getDay()]) {
+        } else if (serviceDayMap[serviceKey][refDate.getDay()] === "1") {
           return acc.concat(getEta(freq[serviceKey], refDate)).sort();
         }
       }


### PR DESCRIPTION
`getUpcomingFerry` ignores the service-day mask on non-holidays, so a ferry returns ETAs on days it does not run.

The values are the strings `"0"` / `"1"`, so the bare truthy check matches `"0"` too. Three lines above, the holiday branch already compares `=== "1"` — this makes the non-holiday branch match it.

<details>
<summary>Impact on the live route DB, and how it was verified</summary>

Against the current `routeFareList.min.json`: **29 ferry routes, 27 with timetables, and 54 service-id entries whose mask contains a `0`** — every one of those is currently ignored. The distinct affected masks are `1000001`, `0000001`, `1000000`, `0111110`, `0111111`, i.e. genuine weekend-only / weekday-only services.

Concretely, `7021 KAI TAK ↔ NORTH POINT` carries service id `288` with mask `0000001` (Saturday only) and `448` with `1000000` (Sunday only). Today both are returned every day of the week.

**Checked that this cannot silently switch ferry ETAs off:** all 6 ferry service-ids resolve to a mask that is present and contains at least one `"1"` — none are missing or all-zero, so no service loses its ETAs on the days it actually runs.

**Regression fixture.** `getUpcomingFerry` samples the next 24 hours (`refDate.setUTCHours(+8 + idx)` over 24 iterations), so sampling from a Sunday also covers Monday — a "Monday-only" mask therefore returns ETAs either way and cannot isolate the bug. Driving the real exported function with an all-zero mask (a service that runs on no day at all):

```
before -> 2 ETAs returned
after  -> 0 ETAs returned
```

`yarn jest` passes locally (2 suites, 3 tests).

Deliberately left alone: I kept this to `=== "1"` to match the existing holiday branch rather than making it tolerant of a numeric mask. If numeric tolerance is wanted, both branches should change together via a shared helper rather than only this line.
</details>
