### PR TITLE
docs: add AGENTS.md for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,156 @@
+# AGENTS.md — hk-bus-eta
+
+Guidance for AI coding agents working in this repository. Humans: see `README.md`.
+
+## What this repo is
+
+The npm package **`hk-bus-eta`**: a small, dependency-light TypeScript library
+that gives one normalised interface to Hong Kong public transport arrival times.
+Every operator publishes ETAs in a different shape on `data.gov.hk`; this package
+hides those differences behind two functions.
+
+```ts
+fetchEtaDb(): Promise<EtaDb>          // the route/stop database
+fetchEtas({ ...routeEntry, seq, language }): Promise<Eta[]>   // live ETAs
+```
+
+It is the data layer of [hkbus.app](https://hkbus.app) and is published to npm
+for third parties. **Its public surface is a contract** — changing the shape of
+`Eta`, `EtaDb` or the arguments of `fetchEtas` breaks downstream consumers you
+cannot see.
+
+`fetchEtaDb` reads `https://data.hkbus.app/routeFareList.min.json` and falls back
+to `https://hkbus.github.io/hk-bus-crawling/routeFareList.min.json` — both are
+published by `hk-bus-crawling`. Live ETAs are fetched straight from the
+operators' `data.gov.hk` endpoints; nothing is proxied.
+
+## Repository family
+
+| Repo | Role |
+| --- | --- |
+| `hkbus/hk-bus-eta` | **this repo** — the npm ETA package |
+| `hkbus/hk-bus-crawling` | builds `routeFareList.min.json` (what `fetchEtaDb` downloads) **and** the twin Python package, also called `hk-bus-eta` |
+| `hkbus/hk-independent-bus-eta` | the hkbus.app React PWA, the main consumer |
+| `hkbus/route-waypoints` | route polylines for the map |
+
+**Triage rule.** Wrong ETA time, missing remark, malformed operator response →
+here. Missing route, wrong stop order, wrong direction → `hk-bus-crawling`.
+Rendering → the app.
+
+## Layout
+
+```text
+src/
+  index.ts        fetchEtas / fetchEtaDb / fetchEtaDbMd5 — the public surface
+  type.ts         Company, Eta, EtaDb, RouteListEntry, StopList, Freq …
+  utils.ts        shared helpers (time parsing, timezone)
+  journeyTime.ts  journey-time lookup
+  kmb.ts ctb.ts nlb.ts gmb.ts lrtfeeder.ts lightRail.ts mtr.ts
+  sunferry.ts fortuneferry.ts hkkf.ts        one module per operator
+test/
+  index.test.ts       fetches the live DB (network-dependent)
+  lrtfeeder.test.ts   fixture-driven, offline
+  K18_en.fixture.json real captured operator payload
+```
+
+Each operator module exports a function taking a normalised argument object and
+returning `Eta[]`. `index.ts` dispatches over the route's `co` array. Adding an
+operator means: a new module, a new `Company` literal in `type.ts`, a new branch
+in `fetchEtas`, and matching support in `hk-bus-crawling`.
+
+`Company` is currently: `kmb`, `nlb`, `ctb`, `lrtfeeder`, `gmb`, `lightRail`,
+`mtr`, `sunferry`, `hkkf`, `fortuneferry`.
+
+## Commands
+
+```sh
+yarn install          # see the Yarn note below
+yarn test             # jest (ts-jest preset)
+yarn build            # tsc → dist/ (CJS, es2015) and esm/ (ESM, es2018)
+yarn clean            # rimraf esm dist
+```
+
+### Yarn: this repo uses Yarn 1 (Classic), and the lockfile is stale
+
+`yarn.lock` is a `# yarn lockfile v1` file. Modern Yarn (Berry 2+/corepack)
+refuses it outright — *"This package doesn't seem to be present in your
+lockfile"*. Use Yarn Classic:
+
+```sh
+npx yarn@1.22.22 install
+```
+
+Note that `--frozen-lockfile` currently **fails even under Yarn Classic**: the
+committed `yarn.lock` has drifted from `package.json` (it still pins the
+jest 29.6.x tree while `package.json` asks for `^29.7.0`, and similarly for other
+dev dependencies). A plain `yarn install` works and updates the lockfile. If you
+are not deliberately fixing that drift, **do not commit the regenerated
+`yarn.lock`** alongside an unrelated change — keep the diff to one concern.
+
+Also be aware that Yarn Classic runs the `prepublish` script during
+`yarn install`, which chains `prebuild` → `clean` + `test`. An install can
+therefore fail on a test or a missing binary before dependencies have settled;
+running `npx jest` directly afterwards is the reliable way to see the real test
+result.
+
+## No CI
+
+There is **no CI workflow in this repository** — `.github/` contains only
+`FUNDING.yml`. Nothing runs your tests, your build, or a type check when you open
+a PR. You are the gate:
+
+```sh
+npx yarn@1.22.22 install
+npx jest          # expect: 2 suites, 3 tests passing
+npx tsc --noEmit  # type check
+npx yarn@1.22.22 build
+```
+
+Paste that output into the PR. A reviewer has no other signal.
+
+## Testing conventions
+
+- **Prefer fixture-driven tests.** `lrtfeeder.test.ts` is the model: capture a
+  real operator payload into `test/<route>_<lang>.fixture.json`, mock
+  `global.fetch` with it, and assert on the normalised `Eta[]`. This makes
+  operator quirks reproducible without depending on live services or on a bus
+  actually running.
+- `index.test.ts` hits the **live network** (`fetchEtaDb`). It will fail offline
+  or if `data.hkbus.app` is down — that is not your change.
+- When fixing an operator quirk, add a fixture that fails before your fix and
+  passes after. Confirm it actually fails without the fix; a test that was green
+  the whole time proves nothing.
+- Comment fixtures with where and when the payload came from, as
+  `K18_en.fixture.json` does.
+
+## House rules
+
+- **Minimal, single-concern diffs.** No drive-by refactors, no dependency bumps
+  bundled with a fix, no reformatting untouched code.
+- **Comments are rare and terse** — one short line where the *why* is not
+  obvious. Reasoning goes in the PR body.
+- **Do not break the public API.** `type.ts` and the signatures in `index.ts` are
+  consumed by hkbus.app and by third parties. Additive changes (new optional
+  field, new operator) are fine; renames and shape changes are not, unless raised
+  first.
+- **`strict: true`** is on. Keep it that way; no `@ts-ignore` to get past a real
+  type problem.
+- **Runtime dependencies are deliberately few** (`date-fns` family only). Do not
+  add one without raising it first — this package ships into a PWA where bundle
+  size is visible to users.
+- **Operator APIs are public government endpoints.** They rate-limit and they go
+  down. Handle malformed and partial responses defensively rather than assuming a
+  field exists; a thrown exception in one operator should not take down the ETAs
+  for the others on the same route.
+- Formatting: Prettier is a dev dependency, no config file, so defaults apply.
+  Nothing enforces it automatically — keep diffs Prettier-clean by hand.
+
+## Publishing
+
+`npm version` / `package.json` `version` drives the release; `prepublish` runs
+`build`, which runs `clean` and `test` first. Publishing is the maintainer's
+call — do not bump the version in a PR unless asked.
+
+## Licence
+
+GPL-3.0-only.


### PR DESCRIPTION
**Adds a single new file, `AGENTS.md`** — onboarding for AI coding agents (Claude Code, Codex, Cursor, …). No code or config is touched.

### Why

This package has **no CI at all** — `.github/` contains only `FUNDING.yml` — so nothing catches a broken build, a failed test or a type error on a PR. That makes written guidance the only gate, and it makes the "verify it yourself and paste the output" instruction the most load-bearing part of the file.

It also has a public API that hkbus.app and unknown third parties depend on, which an agent has no way to infer from the source alone.

<details>
<summary><b>What it covers</b></summary>

| Section | Content |
| --- | --- |
| What this repo is | the two public functions, and where `fetchEtaDb` actually fetches from (incl. the `hkbus.github.io` fallback) |
| Repo family | triage rule — wrong ETA here, wrong route in the crawler, rendering in the app |
| Layout | one module per operator, the `Company` union, what adding an operator entails |
| Commands | install / test / build, and the Yarn caveats below |
| No CI | the exact commands to run and paste, since no bot will |
| Testing | fixture-driven pattern, the live-network test, "see it fail without the fix" |
| House rules | public API is a contract, `strict: true` stays, keep runtime deps few |

</details>

<details>
<summary><b>Verification — commands actually run in this working tree</b></summary>

```
$ npx yarn@1.22.22 install     → succeeds (lockfile updated)
$ npx jest                     → 2 suites, 3 tests passed
```

**Two install traps found and documented.**

1. The machine's default Yarn (Berry 4.17.0) refuses the Yarn 1 lockfile outright:

   ```
   YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
   Internal Error: hk-bus-eta@workspace:.: This package doesn't seem to be present in your lockfile
   ```

2. **The committed `yarn.lock` has drifted from `package.json`**, so `--frozen-lockfile` fails *even under Yarn Classic*:

   ```
   $ npx yarn@1.22.22 install --frozen-lockfile
   error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
   ```

   The drift is the jest toolchain — the lockfile still resolves the `29.6.x` tree while `package.json` asks for `^29.7.0`:

   ```
   - "@jest/core@^29.6.4":        + "@jest/core@^29.7.0":
   - "@jest/transform@^29.6.4":   + "@jest/transform@^29.7.0":
   - "@types/jest@^29.5.4":       + "@types/jest@^29.5.14":     (and the rest of the tree)
   ```

   With no CI, nothing was ever going to notice. **This PR does not fix it** — that is a separate concern and a separate diff; `yarn.lock` was restored untouched here. The file documents the symptom so the next agent does not silently commit a regenerated lockfile alongside an unrelated change.

Also noted: Yarn Classic runs `prepublish` during `yarn install`, which chains `prebuild` → `clean` + `test`, so an install can fail on a test before dependencies have settled. `npx jest` afterwards is the reliable read.

</details>

### How this was verified

Nothing here was written from memory. Every claim was checked against this repo's actual source, then put through two rounds of adversarial review by a **different model lineage** (Codex, prompted to *refute* the concrete claims rather than approve them). The review found real errors both times — which is the reason to trust the current text, not the fact that it eventually passed.

<details>
<summary><b>Round 1 — four factual errors caught and fixed</b></summary>

Codex was pointed at this working tree and asked to verify commands against `package.json`/workflows, verify paths exist, verify the described pipeline matches `.github/workflows`, and verify stated conventions against what the code and on-disk files actually do.

Across the four files it found four MUST-FIX errors across the set.

**On this file specifically:** round 1 found no errors in it — *"No major gaps found in the `hk-bus-eta` … AGENTS file. Their command, layout, CI, filename, and source-contract claims matched the checked source."* The four errors below were in the sibling repos' files, which were reviewed in the same pass.
 Each was **independently re-verified against source before being fixed** — a reviewer's finding is a lead, not a fact:

1. **Prettify described as a PR gate.** `prettify.yml` is `on: [push]`; only `node.js.yml` has `pull_request`. Confirmed against real merged PRs — `gh pr checks` shows only `build (20.x)` / `build (22.x)`.
2. **Crawler pipeline order wrong** — `gmb.py` and the ferry crawlers were grouped with the other operators; `fetch-data.yml` runs them *after* the GTFS stages.
3. **Raw route key ≠ the app's key** — the app uppercases and hyphenates it in `src/db.ts`.
4. **JSON conventions over-generalised** — `ensure_ascii=False` + compact separators are `mergeRoutes.py`'s intermediates only; the final artifact uses a plain `json.dump`.

Score at this point: **7/10**, verdict *"fit to propose upstream after the four must-fix corrections."*

</details>

<details>
<summary><b>Round 2 — re-review of the corrected files</b></summary>

The corrected versions were sent back for a fresh read, with an explicit instruction that the reviewer had *not* seen the current text and should apply the same skepticism. It verified each fix landed correctly rather than merely changed — the Prettify claim in both places it appears, the pipeline table line-for-line against `fetch-data.yml`, the key-normalisation wording against `mergeRoutes.py` and the app's `db.ts`, and the JSON conventions against both writers.

Result: **9/10, zero MUST-FIX remaining**, no new factual errors, no internal contradictions, verdict *"Fit to propose upstream: yes."*

One wording nit was raised and applied: I had written that Prettify "never appears in a PR's checks list", which claims more than the YAML proves — softened to "not triggered by the PR event".

**Honest limitation:** the reviewer could not reproduce the `autopep8` diff counts (the tool was not available in its sandbox). It verified the claim's shape and the workflow arguments; the numbers rest on runs in this checkout, shown above.

</details>

<details>
<summary><b>Scope</b></summary>

```
$ git diff upstream/master...HEAD --stat
 AGENTS.md | 155 +++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 155 insertions(+)
```

One added file. `yarn.lock` deliberately unchanged.

</details>
