### PR TITLE
Allow an optional upper headway bound in Freq

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The data structure of _EtaDb_ is as follows:
             faresHoliday: string[] | null,
             freq: {
                 [type: string]: {
-                    [startTime: string]: [string, string] | null
+                    [startTime: string]: [string, string, string?] | null
                 }
             } | null,
             jt: string | null,

--- a/src/type.ts
+++ b/src/type.ts
@@ -17,7 +17,7 @@ export type Terminal = {
 
 export type Freq = {
   [key in string]: {
-    [startTime: string]: [string, string] | null;
+    [startTime: string]: [string, string, string?] | null;
   };
 };
 


### PR DESCRIPTION
Groundwork for hkbus/hk-bus-crawling#61 (GMB headway ranges shown as a single number).

**TL;DR** — GMB publishes `frequency_upper`, so a headway can be a range ("every 7-10 minutes"). Widening the tuple to an optional third element is purely additive: existing 2-element entries and `null` stay valid, so no consumer breaks.

This is the first of three coordinated changes. The crawler emits the value and the app renders it, but **both depend on this shipping and being published to npm first** — the app cannot typecheck against a 2-tuple.

<details>
<summary><b>Verification</b></summary>

- `tsc --noEmit` with the repo's pinned TypeScript 5.9.3: **0 errors in `src/`**. It does emit 4 errors, all inside `node_modules/@types/node`, and those are present identically on unmodified master — pre-existing environment noise, not from this change.
- `jest`: 2 suites, 3 tests, all passing.
- `yarn.lock` deliberately untouched: a local install rewrites it (yarn 4 locally vs this repo's v1-format lock), which would add unrelated churn.

</details>

<details>
<summary><b>Why an optional element rather than a union</b></summary>

`[string, string, string?]` keeps existing `details === null` narrowing intact and lets every current consumer that reads `[0]` / `[1]` carry on unchanged. A `[string, string] | [string, string, string]` union is stricter and more self-documenting, but would force narrowing at call sites that have no interest in the third element. Happy to switch if you'd prefer the union.

</details>
